### PR TITLE
convox: Default description to commit SHA

### DIFF
--- a/lib/dpl/provider/convox.rb
+++ b/lib/dpl/provider/convox.rb
@@ -29,7 +29,7 @@ module DPL
 
       def push_app
         deploy_cmd = "convox deploy --app #{options[:app]} --rack #{options[:rack]}"
-        deploy_cmd << " --description #{options[:description]}" if options[:description]
+        deploy_cmd << " --description #{build_description}"
         error "Failed to deploy app" unless context.shell deploy_cmd
 
         if options[:copy_to_app]
@@ -39,6 +39,12 @@ module DPL
           copy_cmd << " | convox builds import --app #{options[:copy_to_app]} --rack #{copy_to_rack}"
           context.shell copy_cmd
         end
+      end
+
+      private
+
+      def build_description
+        options[:description] || sha
       end
 
     end

--- a/spec/provider/convox_spec.rb
+++ b/spec/provider/convox_spec.rb
@@ -31,6 +31,10 @@ describe DPL::Provider::Convox do
   end
 
   describe "#push_app" do
+    before do
+      allow(provider.context.env).to receive(:[]).with('TRAVIS_COMMIT').and_return('commit-sha')
+    end
+
     it 'should include description if specified' do
       provider.options.update(:description => 'something')
       expect(provider.context).to receive(:shell).with(
@@ -42,7 +46,7 @@ describe DPL::Provider::Convox do
     it 'should copy build to another app in the same rack' do
       provider.options.update(:copy_to_app => 'another-app')
       expect(provider.context).to receive(:shell).with(
-        "convox deploy --app dummy-app --rack dummy-rack"
+        "convox deploy --app dummy-app --rack dummy-rack --description commit-sha"
       ).and_return(true)
       expect(provider.context).to receive(:shell).with(
         "convox builds export $(convox builds --app dummy-app --rack dummy-rack | awk 'NR==2 {print $1}') --app dummy-app --rack dummy-rack | convox builds import --app another-app --rack dummy-rack"
@@ -54,7 +58,7 @@ describe DPL::Provider::Convox do
       provider.options.update(:copy_to_app => 'another-app')
       provider.options.update(:copy_to_rack => 'another-rack')
       expect(provider.context).to receive(:shell).with(
-        "convox deploy --app dummy-app --rack dummy-rack"
+        "convox deploy --app dummy-app --rack dummy-rack --description commit-sha"
       ).and_return(true)
       expect(provider.context).to receive(:shell).with(
         "convox builds export $(convox builds --app dummy-app --rack dummy-rack | awk 'NR==2 {print $1}') --app dummy-app --rack dummy-rack | convox builds import --app another-app --rack another-rack"


### PR DESCRIPTION
If `description` opt is not specified use commit SHA (either
$TRAVIS_COMMIT or `git rev-parse HEAD`). This way each build can be
correlated with code change.